### PR TITLE
feat: Add re-ranking to the retrieval process

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -101,6 +101,7 @@ def run() -> None:
         "Chat model", value=st.session_state.get("chat_model", "gpt-4o-mini")
     )
     top_k = sidebar.slider("Top K context chunks", min_value=1, max_value=10, value=3)
+    rerank = sidebar.checkbox("Enable Re-ranking", value=False)
 
     vector_path = Path(vector_path_str)
     chain: Optional[QaChain] = None
@@ -182,7 +183,9 @@ def run() -> None:
                         {"role": msg["role"], "content": msg["content"]}
                         for msg in st.session_state["messages"][:-1]
                     ]
-                    result = chain.ask(prompt, chat_history=chat_history, top_k=top_k)
+                    result = chain.ask(
+                        prompt, chat_history=chat_history, top_k=top_k, rerank=rerank
+                    )
                     st.markdown(result.answer)
                     _render_sources(result.sources)
                     st.session_state["messages"].append(


### PR DESCRIPTION
This commit introduces a re-ranking step to the retrieval process, which improves the quality of the answers by using a language model to score the relevance of the retrieved document chunks.

Key changes:
- The `QaChain` in `llm/qa_chain.py` has been updated with a `_rerank_documents` method that uses an LLM to score and re-rank the retrieved documents.
- The `ask` method in `QaChain` now accepts a `rerank` parameter to enable or disable this feature.
- A checkbox has been added to the Streamlit UI in `app/main.py` to allow users to toggle the re-ranking feature.